### PR TITLE
docs: update notebook examples to match contributing guidelines

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 367c229274f328bf7e08d4f094731a000977494b
+_commit: 34af1eded43e8feca2f8d2a5b8f1eca86b359317
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 174d455a5648f2d383eb8b2d4376f88d1dd17563
+_commit: 367c229274f328bf7e08d4f094731a000977494b
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -48,11 +48,50 @@ def on_pre_build(config):
     docs_examples = project_root / "docs" / "examples"
     docs_examples.mkdir(parents=True, exist_ok=True)
 
-    # Export each notebook
+    # Export each notebook in both static HTML and interactive WASM formats
     for notebook in notebooks:
         output_dir = docs_examples / notebook.stem
-        output_file = output_dir / "index.html"
+
+        # Clean previous export artifacts before re-exporting
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Export static HTML (read-only view)
+        static_file = output_dir / "index.html"
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "marimo",
+                    "-y",
+                    "-q",
+                    "export",
+                    "html",
+                    str(notebook),
+                    "-o",
+                    str(static_file),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            print(
+                f"[hooks] exported html {notebook.relative_to(project_root)} -> {static_file.relative_to(project_root)}"
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"[hooks] Error exporting html {notebook.name}: {e}", file=sys.stderr)
+            if e.stderr:
+                print(e.stderr, file=sys.stderr)
+        except FileNotFoundError:
+            print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
+            break
+
+        # Export interactive WASM (editable in-browser)
+        edit_dir = output_dir / "edit"
+        edit_file = edit_dir / "index.html"
+        edit_dir.mkdir(parents=True, exist_ok=True)
 
         try:
             subprocess.run(
@@ -66,7 +105,7 @@ def on_pre_build(config):
                     "html-wasm",
                     str(notebook),
                     "-o",
-                    str(output_file),
+                    str(edit_file),
                     "--mode",
                     "edit",
                 ],
@@ -74,9 +113,11 @@ def on_pre_build(config):
                 capture_output=True,
                 text=True,
             )
-            print(f"[hooks] exported {notebook.relative_to(project_root)} -> {output_file.relative_to(project_root)}")
+            print(
+                f"[hooks] exported html-wasm {notebook.relative_to(project_root)} -> {edit_file.relative_to(project_root)}"
+            )
         except subprocess.CalledProcessError as e:
-            print(f"[hooks] Error exporting {notebook.name}: {e}", file=sys.stderr)
+            print(f"[hooks] Error exporting html-wasm {notebook.name}: {e}", file=sys.stderr)
             if e.stderr:
                 print(e.stderr, file=sys.stderr)
         except FileNotFoundError:
@@ -423,7 +464,7 @@ def on_post_build(config):
     project_root = Path(__file__).parent.parent
     docs_examples = project_root / "docs" / "examples"
 
-    # Copy standalone HTML example files
+    # Copy standalone HTML example files (both static and WASM/edit)
     if docs_examples.exists():
         for html_dir in docs_examples.iterdir():
             if not html_dir.is_dir() or html_dir.name.startswith("."):
@@ -437,13 +478,37 @@ def on_post_build(config):
             target_dir = site_dir / "examples" / html_dir.name
             target_dir.mkdir(parents=True, exist_ok=True)
 
-            # Copy index.html and all other files in the directory
+            # Copy top-level files (static HTML export)
             for file in html_dir.iterdir():
-                if file.name == "CLAUDE.md":
+                if file.name == "CLAUDE.md" or file.is_dir():
                     continue
-                target_file = target_dir / file.name
-                if file.is_file():
-                    shutil.copy2(file, target_file)
+                shutil.copy2(file, target_dir / file.name)
+
+            # Inject CSS to hide RTD version menu in static HTML
+            _inject_rtd_css(target_dir / "index.html")
+
+            # Copy edit/ subdirectory (WASM export) if it exists
+            edit_src = html_dir / "edit"
+            if edit_src.exists() and edit_src.is_dir():
+                edit_target = target_dir / "edit"
+                if edit_target.exists():
+                    shutil.rmtree(edit_target)
+                shutil.copytree(
+                    edit_src,
+                    edit_target,
+                    ignore=shutil.ignore_patterns("CLAUDE.md"),
+                )
+
+                # Remove CLAUDE.md if MkDocs copied it from docs/ during build
+                claude_md = edit_target / "CLAUDE.md"
+                if claude_md.exists():
+                    claude_md.unlink()
+
+                # Fix the marimo filename in WASM export only
+                _fix_marimo_filename(edit_target / "index.html", html_dir.name)
+
+                # Inject CSS to hide RTD version menu in WASM export
+                _inject_rtd_css(edit_target / "index.html")
 
             # Fix the marimo filename to show the actual notebook name in browser tabs
             _fix_marimo_filename(target_dir / "index.html", html_dir.name)
@@ -454,8 +519,8 @@ def on_post_build(config):
             print(f"[hooks] copied examples/{html_dir.name}/ to site")
 
     # Get exclude patterns from config
-    # Note: mkdocs converts exclude_docs to a GitIgnoreSpec object, so we use an empty list
-    exclude_patterns = []
+    # Note: mkdocs converts exclude_docs to a GitIgnoreSpec object, so we hardcode patterns
+    exclude_patterns = ["examples/**/CLAUDE.md"]
 
     # Remove legacy llm/ directory if it exists
     legacy_dir = site_dir / "llm"

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -387,59 +387,129 @@ just --list
 
 ### Adding Examples
 
-All examples are interactive [marimo](https://marimo.io) notebooks that combine code, markdown, and visualizations. Follow these guidelines:
+All examples are interactive [marimo](https://marimo.io) notebooks that combine code, markdown, and visualizations.
 
-1. Create a new marimo notebook in `examples/<name>.py`:
+#### Creating a Notebook
 
-   === "just"
+Create a new marimo notebook in `examples/<name>.py`:
 
-       ```bash
-       just example <name>.py
-       ```
+=== "just"
 
-   === "uv run"
+    ```bash
+    just example <name>.py
+    ```
 
-       ```bash
-       uv run marimo new examples/<name>.py
-       ```
+=== "uv run"
 
-2. Develop your example in the marimo editor, ollowing the standardized structure:
-   - **Overview**: Explain what readers will learn (flexible length)
+2. Develop your example in the marimo editor, following the standardized structure:
    - **Numbered sections**: Main concepts as `## 1.`, `## 2.`, `## 3.`
    - **Key Takeaways**: Bullet points summarizing important lessons
-   - **Next Steps**: Context for progression to related notebooks
-   - Use `hide_code=True` for utility functions (sliders, data generation, visualization)
+   - **Next Steps**: Links to related notebooks for progression
+   - Isolate utilities and markdown in separate cells
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
 
-3. Run the example test suite to verify it passes:
+   **Pyodide install cell template** (place right after `import marimo as mo`):
 
-   === "just"
+   ```python
+   @app.cell(hide_code=True)
+   async def _():
+       import sys
 
-       ```bash
-       just test-examples
-       ```
+       if "pyodide" in sys.modules:
+           import micropip
 
-   === "nox"
-
-       ```bash
-       uvx nox -s test_examples
-       ```
-
-   === "uv run"
-
-       ```bash
-       uv run pytest tests/test_examples.py -m example
-       ```
-
-4. Add a link to your example in `docs/pages/examples.md`:
-
-   ```markdown
-   - [Example Name](../examples/<name>/) - Brief description
+           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
+       return
    ```
 
-5. The mkdocs hooks automatically exports notebooks to HTML during docs build
+   **`hide_code=True` guidance** — mark these cells as hidden:
 
-All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
+   | Cell type | Why hidden |
+   |-----------|-----------|
+   | `import marimo as mo` | Boilerplate, not instructive |
+   | Pyodide install | Infrastructure, not tutorial content |
+   | Library imports | Setup, readers focus on usage |
+   | Utilities | Not the lesson |
+   | Markdown cells | Purely structural |
 
+   Leave these cells **visible**:
+
+   | Cell type | Why visible |
+   |-----------|------------|
+   | Model construction / `MyEstimator(...)` | Core teaching content |
+   | `search.fit(...)` calls | Demonstrates usage |
+   | Results display | Shows output interpretation |
+
+#### Required Structure
+
+Every example notebook **must** follow this structure in order:
+
+1. **Title**: A top-level `# Title` heading describing the notebook topic
+2. **What You'll Learn**: A `## What You'll Learn` section with a bulleted list of concrete learning goals
+3. **Prerequisites**: A `## Prerequisites` section stating required prior knowledge (one-liner or short bullet list). For standalone dataset explorations, use "None -- this is a standalone dataset exploration."
+4. **Numbered sections**: Main content as `## 1. Section Name`, `## 2. Section Name`, etc.
+5. **Key Takeaways**: A `## Key Takeaways` section with bullet points summarizing important lessons learned
+6. **Next Steps**: A `## Next Steps` section with bullet points linking to related notebooks or documentation
+
+**Example intro cell**:
+
+```markdown
+# Reduction Forecasting with sklearn
+
+## What You'll Learn
+
+- How `PointReductionForecaster` tabularizes time series data using lag features
+- The difference between `target_transformer` and `feature_transformer` parameters
+- Tuning hyperparameters with `GridSearchCV`
+
+## Prerequisites
+
+Basic familiarity with sklearn's fit/predict API and time series concepts (trend, seasonality).
+```
+
+#### Marimo Cell Conventions
+
+- Use `hide_code=True` on all markdown cells, import cells, and utility/helper cells
+- The second cell (after `import marimo as mo`) must be the Pyodide/micropip guard for browser compatibility
+- Group all imports into a single hidden cell after the Pyodide guard
+- The overview markdown cell (with `# Title`, `## What You'll Learn`, `## Prerequisites`) follows the imports
+
+#### Content Guidelines
+
+- **Markdown density**: Each numbered section should open with a descriptive markdown cell explaining the concept before any code cells. Consecutive code cells within the same section are acceptable when logically grouped.
+- **No emojis**: Do not use emojis anywhere in notebooks -- not in headings, content bullets, or concluding remarks.
+- **Key Takeaways format**: Use bold for key terms with plain descriptions (e.g., `- **Reduction forecasting** converts time series into tabular regression via lag features`)
+- **Next Steps format**: Use bold labels with brief descriptions (e.g., `- **Naive baselines**: See naive_forecasters.py to compare with simple benchmarks`)
+
+#### Testing and Documentation
+
+Run the example test suite to verify your notebook passes:
+
+=== "just"
+
+    ```bash
+    just test-examples
+    ```
+
+=== "nox"
+
+    ```bash
+    uvx nox -s test_examples
+    ```
+
+=== "uv run"
+
+    ```bash
+    uv run pytest tests/test_examples.py -m example
+    ```
+
+Add a link to your example in `docs/pages/examples.md`:
+
+```markdown
+- [Example Name](../examples/<name>/) - Brief description
+```
+
+The mkdocs hooks automatically export notebooks to HTML during docs build. All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
 
 ## Submitting Changes
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -1,40 +1,42 @@
 # Examples
 
-Explore real-world applications of Sklearn-Optuna through interactive examples.
+Explore real-world applications of Sklearn-Optuna through interactive examples. Each notebook is available in two formats: **View** for static reading, and **Editable** for an interactive WASM notebook that runs entirely in your browser (no server needed).
 
-## What can Sklearn-Optuna do?
+## Getting Started
 
-### Example 1: [OptunaSearchCV Quickstart](/examples/quickstart/)
+### OptunaSearchCV Quickstart ([View](/examples/quickstart/) | [Editable](/examples/quickstart/edit/))
 
 Learn how to run a fast hyperparameter search and read the best parameters and score. This example shows the fastest path from data to optimized model using familiar Scikit-Learn patterns.
 
 This walkthrough uses a compact search space and a small number of trials to keep results quick and readable.
 
-### Example 2: [Study Management and Reproducibility](/examples/study_management/)
+### Study Management and Reproducibility ([View](/examples/study_management/) | [Editable](/examples/study_management/edit/))
 
 Reuse an Optuna study to continue optimization runs and keep experiments reproducible with seeded samplers. This notebook demonstrates how to resume trials and compare total trial counts.
 
 This example focuses on study reuse and reproducibility without changing the core Scikit-Learn API flow.
 
-### Example 3: [Optuna Visualizations](/examples/visualization/)
+### Optuna Visualizations ([View](/examples/visualization/) | [Editable](/examples/visualization/edit/))
 
 Turn completed studies into visual summaries of optimization history and parameter importance. This helps explain how the search progressed and which hyperparameters mattered most.
 
 The notebook uses `study_` to generate interactive plots that make diagnostics easy to interpret.
 
-### Example 4: [Early Stopping with Callbacks](/examples/callbacks/)
+## Advanced Patterns
+
+### Early Stopping with Callbacks ([View](/examples/callbacks/) | [Editable](/examples/callbacks/edit/))
 
 Stop unneeded work early by adding Optuna callbacks to your search. This example shows how to integrate a max-trials callback for quick experimentation.
 
 It demonstrates how to pass a dictionary of callbacks through `OptunaSearchCV` without changing your estimator code.
 
-### Example 5: [Nested OptunaSearchCV in Pipelines](/examples/nested_pipeline/)
+### Nested OptunaSearchCV in Pipelines ([View](/examples/nested_pipeline/) | [Editable](/examples/nested_pipeline/edit/))
 
 Discover advanced nested optimization patterns where `OptunaSearchCV` serves as a final estimator in a pipeline tuned by another `OptunaSearchCV`. This example shows how to tune preprocessing choices and sampler parameters simultaneously.
 
 This walkthrough demonstrates tuning sampler parameters like `n_startup_trials` using nested parameter syntax and highlights the computational trade-offs of nested searches.
 
-### Example 6: [Metadata Routing with sample_weight](/examples/metadata_routing/)
+### Metadata Routing with sample_weight ([View](/examples/metadata_routing/) | [Editable](/examples/metadata_routing/edit/))
 
 Handle imbalanced datasets by routing `sample_weight` through `OptunaSearchCV` to both model fitting and scoring. This example shows how to configure metadata routing for estimators, scorers, and pipelines.
 

--- a/docs/pages/user-guide.md
+++ b/docs/pages/user-guide.md
@@ -54,7 +54,7 @@ search.cv_results_       # full results dict
 search.best_estimator_   # refitted model
 ```
 
-**Example:** See the [Quickstart notebook](/examples/quickstart/) for a complete walkthrough.
+**Example:** See the Quickstart notebook ([View](/examples/quickstart/) | [Editable](/examples/quickstart/edit/)) for a complete walkthrough.
 
 ### Wrapper classes: Sampler, Storage, Callback
 
@@ -115,7 +115,7 @@ search = OptunaSearchCV(
 )
 ```
 
-**Example:** See the [Callbacks notebook](/examples/callbacks/) for early stopping patterns.
+**Example:** See the Callbacks notebook ([View](/examples/callbacks/) | [Editable](/examples/callbacks/edit/)) for early stopping patterns.
 
 ### Study persistence and reuse
 
@@ -133,7 +133,7 @@ search.fit(X, y)
 search.fit(X, y, study=search.study_)
 ```
 
-**Example:** See the [Study Management notebook](/examples/study_management/) for reproducibility patterns.
+**Example:** See the Study Management notebook ([View](/examples/study_management/) | [Editable](/examples/study_management/edit/)) for reproducibility patterns.
 
 ### Multi-metric scoring
 
@@ -147,7 +147,7 @@ search = OptunaSearchCV(
 )
 ```
 
-**Example:** See the [Metadata Routing notebook](/examples/metadata_routing/) for advanced scoring patterns with `sample_weight`.
+**Example:** See the Metadata Routing notebook ([View](/examples/metadata_routing/) | [Editable](/examples/metadata_routing/edit/)) for advanced scoring patterns with `sample_weight`.
 
 ### Training scores and error handling
 
@@ -176,7 +176,7 @@ param_distributions = {
 search = OptunaSearchCV(pipe, param_distributions, n_trials=20)
 ```
 
-**Example:** See the [Nested Pipeline notebook](/examples/nested_pipeline/) for advanced nested search patterns.
+**Example:** See the Nested Pipeline notebook ([View](/examples/nested_pipeline/) | [Editable](/examples/nested_pipeline/edit/)) for advanced nested search patterns.
 
 ## Configuration
 
@@ -238,7 +238,7 @@ Yes. `OptunaSearchCV` is a valid Scikit-Learn estimator. You can use it as a ste
 
 The study is available as `search.study_` and the trial list as `search.trials_`. You can pass `search.study_` to Optuna's visualization functions directly.
 
-**Example:** See the [Visualization notebook](/examples/visualization/) for plotting optimization history and parameter importance.
+**Example:** See the Visualization notebook ([View](/examples/visualization/) | [Editable](/examples/visualization/edit/)) for plotting optimization history and parameter importance.
 
 ### Can I resume a previous search?
 

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -17,21 +17,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # Callbacks
-
-    **Overview**
-    Learn how to use Optuna callbacks to control optimization behavior in `OptunaSearchCV`.
-    Callbacks are invoked at the end of each trial and can implement custom stopping criteria,
-    logging, or other side effects. This example demonstrates using `MaxTrialsCallback` to
-    stop the search early after a certain number of completed trials, useful for quick
-    experimentation or conditional stopping logic.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -60,6 +45,24 @@ def _():
         make_classification,
         optuna,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Callbacks
+
+    ## What You'll Learn
+
+    - How to wrap Optuna callbacks with sklearn-optuna's `Callback` wrapper
+    - How to pass a dictionary of callbacks to `OptunaSearchCV`
+    - How callbacks can override default stopping behavior (e.g., early stopping)
+
+    ## Prerequisites
+
+    Familiarity with the OptunaSearchCV quickstart (see quickstart.py).
+    """)
+    return
 
 
 @app.cell
@@ -135,10 +138,14 @@ def _(
 
 
 @app.cell
-def _(mo, search):
+def _(search):
     # Check how many trials actually ran
     n_trials_run = len(search.study_.trials)
+    return (n_trials_run,)
 
+
+@app.cell(hide_code=True)
+def _(mo, n_trials_run):
     mo.md(f"Requested trials: 20\nActual trials run: {n_trials_run}")
     return
 
@@ -147,9 +154,15 @@ def _(mo, search):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - Wrap Optuna callbacks with `Callback`.
-    - Pass a dictionary of callbacks to `OptunaSearchCV`.
-    - Useful for stopping criteria beyond simple trial counts or timeout.
+
+    - **Callback wrapper** -- Wrap Optuna callbacks with `Callback` for sklearn compatibility
+    - **Dictionary interface** -- Pass a dictionary of callbacks to `OptunaSearchCV`
+    - **Custom stopping** -- Useful for stopping criteria beyond simple trial counts or timeout
+
+    ## Next Steps
+
+    - **Nested pipelines**: See nested_pipeline.py for advanced optimization patterns with pipelines
+    - **Metadata routing**: See metadata_routing.py to route sample weights through the search
     """)
     return
 

--- a/examples/metadata_routing.py
+++ b/examples/metadata_routing.py
@@ -18,21 +18,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # Metadata Routing with sample_weight
-
-    **Overview**
-    Demonstrate how to use scikit-learn's metadata routing to pass `sample_weight`
-    through `OptunaSearchCV` to both model fitting and scoring. This is essential
-    for handling imbalanced datasets or when different samples have varying importance.
-
-    Metadata routing requires scikit-learn ≥1.4 and must be explicitly enabled.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -68,6 +53,25 @@ def _():
         make_scorer,
         sklearn,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Metadata Routing with sample_weight
+
+    ## What You'll Learn
+
+    - How to enable and configure scikit-learn's metadata routing for `sample_weight`
+    - How to route metadata through `OptunaSearchCV` to both model fitting and scoring
+    - How to set up multi-metric scoring with different routing preferences
+    - How to handle metadata routing in pipelines with mixed requirements
+
+    ## Prerequisites
+
+    Familiarity with the OptunaSearchCV quickstart (see quickstart.py) and scikit-learn metadata routing (requires sklearn >= 1.4).
+    """)
+    return
 
 
 @app.cell(hide_code=True)
@@ -294,18 +298,19 @@ def _(mo, search_pipe):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - Enable metadata routing with `sklearn.config_context(enable_metadata_routing=True)`.
-    - Use `.set_fit_request(sample_weight=True)` and `.set_score_request(sample_weight=True)`
-      to configure estimators.
-    - Pass metadata as keyword arguments to `fit()`: `search.fit(X, y, sample_weight=weights)`.
-    - Different scorers can have different routing preferences in multi-metric scenarios.
-    - In pipelines, each step can independently configure its metadata requirements.
-    - Sample weights are essential for handling imbalanced datasets properly.
+
+    - **Enable routing** -- Use `sklearn.config_context(enable_metadata_routing=True)` to activate metadata routing
+    - **Request configuration** -- Use `.set_fit_request(sample_weight=True)` and `.set_score_request(sample_weight=True)` on estimators
+    - **Pass as kwargs** -- Pass metadata as keyword arguments to `fit()`: `search.fit(X, y, sample_weight=weights)`
+    - **Mixed routing** -- Different scorers can have different routing preferences in multi-metric scenarios
+    - **Pipeline support** -- Each pipeline step can independently configure its metadata requirements
+    - **Imbalanced data** -- Sample weights are essential for handling imbalanced datasets properly
 
     ## Next Steps
-    - Explore other metadata like `groups` for GroupKFold cross-validation.
-    - Try custom metadata for domain-specific information.
-    - Combine metadata routing with callbacks for advanced workflows.
+
+    - **Group cross-validation**: Explore routing `groups` for GroupKFold cross-validation
+    - **Custom metadata**: Try custom metadata for domain-specific information
+    - **Callbacks**: Combine metadata routing with callbacks for advanced workflows (see callbacks.py)
     """)
     return
 

--- a/examples/nested_pipeline.py
+++ b/examples/nested_pipeline.py
@@ -18,24 +18,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # Nested OptunaSearchCV in Pipelines
-
-    **Overview**
-    Demonstrate an advanced pattern where `OptunaSearchCV` is used as a final
-    estimator in a pipeline that is itself tuned by another `OptunaSearchCV`.
-    This example shows how to tune both preprocessing choices and the sampler
-    parameters of the inner search.
-
-    **⚠️ Performance Note:** Nested searches multiply computational costs
-    (`outer_trials × inner_trials` evaluations). Use this pattern sparingly
-    and with minimal trial counts for exploratory work.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -69,6 +51,28 @@ def _():
         make_classification,
         optuna,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Nested OptunaSearchCV in Pipelines
+
+    ## What You'll Learn
+
+    - How to nest `OptunaSearchCV` as a final estimator inside a pipeline tuned by another `OptunaSearchCV`
+    - How to use double-underscore syntax to tune inner search parameters (e.g., sampler settings)
+    - The computational trade-offs of nested optimization
+
+    ## Prerequisites
+
+    Familiarity with the OptunaSearchCV quickstart (see quickstart.py) and sklearn pipelines.
+
+    **Performance Note:** Nested searches multiply computational costs
+    (`outer_trials x inner_trials` evaluations). Use this pattern sparingly
+    and with minimal trial counts for exploratory work.
+    """)
+    return
 
 
 @app.cell
@@ -205,16 +209,17 @@ def _(mo, outer_search):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - `OptunaSearchCV` can be nested inside pipelines tuned by another `OptunaSearchCV`.
-    - Use `refit=False` on inner searches to save computation time.
-    - Access nested parameters with double-underscore syntax (`classifier__sampler__param`).
-    - Sampler parameters like `n_startup_trials` can be tuned as hyperparameters.
-    - Keep trial counts minimal due to multiplicative computational costs.
+
+    - **Nesting** -- `OptunaSearchCV` can be nested inside pipelines tuned by another `OptunaSearchCV`
+    - **Refit control** -- Use `refit=False` on inner searches to save computation time
+    - **Nested parameters** -- Access nested parameters with double-underscore syntax (`classifier__sampler__param`)
+    - **Sampler tuning** -- Sampler parameters like `n_startup_trials` can be tuned as hyperparameters
+    - **Cost awareness** -- Keep trial counts minimal due to multiplicative computational costs
 
     ## Next Steps
-    - Try tuning other sampler parameters like `seed` or different sampler types.
-    - Experiment with nested searches in ensemble meta-estimators.
-    - Consider whether nested optimization is necessary for your use case.
+
+    - **Metadata routing**: See metadata_routing.py to route sample weights through `OptunaSearchCV`
+    - **Sampler exploration**: Try tuning other sampler parameters or different sampler types
     """)
     return
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -18,21 +18,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # OptunaSearchCV Quickstart
-
-    **Overview**
-    This quickstart demonstrates the fastest path from data to an optimized model using
-    `OptunaSearchCV`. In just a few lines, you'll run a hyperparameter search powered by
-    Optuna's TPE sampler, which intelligently explores the search space to find better
-    parameters faster than grid or random search. The API is identical to sklearn's
-    `GridSearchCV` and `RandomizedSearchCV`, making it a drop-in replacement.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -59,6 +44,24 @@ def _():
         make_classification,
         optuna,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # OptunaSearchCV Quickstart
+
+    ## What You'll Learn
+
+    - How to set up and run `OptunaSearchCV` as a drop-in replacement for sklearn search estimators
+    - How to define search spaces using Optuna distributions
+    - How to read best parameters and score from the completed search
+
+    ## Prerequisites
+
+    Basic familiarity with scikit-learn's fit/predict API and hyperparameter tuning concepts.
+    """)
+    return
 
 
 @app.cell(hide_code=True)
@@ -147,13 +150,15 @@ def _(mo, search):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - `OptunaSearchCV` works like other sklearn search estimators.
-    - Optuna distributions define a flexible search space.
-    - `best_params_` and `best_score_` summarize the best trial.
+
+    - **Drop-in replacement** -- `OptunaSearchCV` works like other sklearn search estimators
+    - **Flexible search spaces** -- Optuna distributions define continuous, discrete, and categorical parameters
+    - **Standard results** -- `best_params_` and `best_score_` summarize the best trial
 
     ## Next Steps
-    - See advanced search spaces for conditional parameters.
-    - Explore callbacks to stop runs early.
+
+    - **Study management**: See study_management.py for resuming and reusing optimization runs
+    - **Callbacks**: See callbacks.py to stop runs early with custom stopping criteria
     """)
     return
 

--- a/examples/study_management.py
+++ b/examples/study_management.py
@@ -17,20 +17,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # Study Management
-
-    **Overview**
-    Learn how to reuse Optuna studies across multiple `OptunaSearchCV` runs. This enables
-    resuming optimization from checkpoints, comparing different configurations with the same
-    study, and maintaining reproducible experiment histories. By passing an existing study
-    to `fit()`, you can continue trials without starting from scratch.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -56,6 +42,24 @@ def _():
         make_classification,
         optuna,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Study Management
+
+    ## What You'll Learn
+
+    - How to create an Optuna study manually and pass it to `OptunaSearchCV`
+    - How to resume optimization from prior trials without starting from scratch
+    - How to maintain reproducible experiment histories across runs
+
+    ## Prerequisites
+
+    Familiarity with the OptunaSearchCV quickstart (see quickstart.py).
+    """)
+    return
 
 
 @app.cell
@@ -122,8 +126,14 @@ def _(mo, search):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - You can create an Optuna Study manually and pass it to `fit(study=...)`.
-    - This allows pausing/resuming searches or sharing studies across runs.
+
+    - **Study reuse** -- Create an Optuna Study manually and pass it to `fit(study=...)` to accumulate trials
+    - **Resume optimization** -- Pausing and resuming searches or sharing studies across runs avoids redundant computation
+
+    ## Next Steps
+
+    - **Visualizations**: See visualization.py to plot optimization history and parameter importance
+    - **Callbacks**: See callbacks.py to add custom stopping criteria to your searches
     """)
     return
 

--- a/examples/visualization.py
+++ b/examples/visualization.py
@@ -17,20 +17,6 @@ def _():
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md("""
-    # Visualization
-
-    **Overview**
-    Visualize optimization history using Optuna's built-in plotting functions. After running
-    `OptunaSearchCV`, access the `study_` attribute to generate interactive plots that reveal
-    how the search progressed, which hyperparameters matter most, and how parameters interact.
-    These visualizations help debug search configurations and communicate results effectively.
-    """)
-    return
-
-
-@app.cell(hide_code=True)
 async def _():
     import sys
 
@@ -56,6 +42,24 @@ def _():
         make_classification,
         optuna,
     )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    # Visualization
+
+    ## What You'll Learn
+
+    - How to access the Optuna `study_` attribute from a completed `OptunaSearchCV`
+    - How to generate optimization history and contour plots using Optuna's visualization module
+    - How to interpret search progress and parameter relationships
+
+    ## Prerequisites
+
+    Familiarity with the OptunaSearchCV quickstart (see quickstart.py). Plotly is used for interactive plots.
+    """)
+    return
 
 
 @app.cell
@@ -123,8 +127,14 @@ def _(optuna, search):
 def _(mo):
     mo.md("""
     ## Key Takeaways
-    - Access `search.study_` to get the Optuna Study object.
-    - Pass `search.study_` to standard Optuna visualization functions.
+
+    - **Study access** -- Use `search.study_` to get the Optuna Study object after fitting
+    - **Built-in plots** -- Pass `search.study_` to standard Optuna visualization functions for interactive Plotly figures
+
+    ## Next Steps
+
+    - **Callbacks**: See callbacks.py to stop trials early based on custom criteria
+    - **Nested pipelines**: See nested_pipeline.py for advanced optimization patterns
     """)
     return
 


### PR DESCRIPTION
## Description

Update all 6 notebook examples and documentation pages to follow contributing guidelines and adopt the View | Editable link pattern from sklearn-wrap.

## Type of Change

- [x] Documentation update

## Motivation and Context

Notebook examples had inconsistent structure (cell ordering, missing sections) and docs used a plain link format instead of the View | Editable pattern.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- Reordered cells: `mo` → pyodide → imports → overview (matching sklearn-wrap convention)
- Added `## What You'll Learn` and `## Prerequisites` to all notebooks
- Reformatted Key Takeaways and Next Steps with bold terms
- Added missing Next Steps to study_management, visualization, and callbacks
- Updated examples.md and user-guide.md with View | Editable links
- Fixed contributing.md to remove contradictory pyodide placement guidance