### PR TITLE
chore: update copier template to 0.13.2

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 34af1eded43e8feca2f8d2a5b8f1eca86b359317
+_commit: b1350d0e5e9792ccf86faba9ee3899075a622462
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -35,9 +37,9 @@ jobs:
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v5
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.12' && env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
 
   create-issue-on-failure:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -86,17 +88,17 @@ jobs:
         run: nox -s test --python ${{ matrix.python-version }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }} && matrix.python-version == '3.11'
+        if: ${{ !cancelled() && matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           file: '${{ github.workspace }}/junit.${{ matrix.python-version }}.xml'
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.python-version == '3.11'
+        if: ${{ matrix.python-version == '3.11' && env.CODECOV_TOKEN != '' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: '${{ github.workspace }}/coverage.${{ matrix.python-version }}.xml'
           env_vars: OS,PYTHON
           fail_ci_if_error: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,8 @@ build:
       # Create the virtual environment using uv
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
-      # Sync doc-dependencies (the group "docs") without installing the project
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs --no-install-project
+      # Sync doc-dependencies (the group "docs") and install the project itself
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
 
 # MkDocs configuration
 mkdocs:

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -412,20 +412,22 @@ def _fix_marimo_filename(html_file: Path, notebook_name: str) -> None:
 
     Marimo exports always use 'notebook.py' as the default filename. This function
     replaces it with the actual notebook name to show the correct title in browser tabs.
+
+    Note: Only the <marimo-filename> display tag is replaced. The config
+    ``"filename"`` field must stay as ``"notebook.py"`` because the marimo WASM
+    worker has that name hard-coded and writes the notebook source to
+    ``/marimo/notebook.py``. Changing the config value would cause a
+    ``FileNotFoundError`` at runtime.
     """
     if not html_file.exists():
         return
 
     html_content = html_file.read_text(encoding="utf-8")
 
-    # Replace both the marimo-filename tag and the config filename
+    # Replace the display tag
     html_content = html_content.replace(
         "<marimo-filename hidden>notebook.py</marimo-filename>",
         f"<marimo-filename hidden>{notebook_name}.py</marimo-filename>",
-    )
-    html_content = html_content.replace(
-        '"filename": "notebook.py"',
-        f'"filename": "{notebook_name}.py"',
     )
 
     html_file.write_text(html_content, encoding="utf-8")


### PR DESCRIPTION
## Description

Update from copier template `python-package-copier` to version 0.13.2.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Copier template update

## Motivation and Context

Keep project scaffolding in sync with the latest upstream template. Key changes:
- CI: Codecov token passed via `env` block; upload steps skipped when token is unavailable
- ReadTheDocs: install the project itself alongside docs dependencies
- Docs hooks: only replace `<marimo-filename>` display tag (config `"filename"` must stay as `"notebook.py"` for WASM worker)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just format` to format my code
- [ ] I have run `just check` to verify type annotations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Generated by `uvx copier update`.