### PR TITLE
feat: replace WASM export with PEP 723 notebooks and marimo.app playground links

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: fdb4552a1ec1bc4eb78639a915006609cc9e2ded
+_commit: d439e067d6a4a123dc84d1c27642e2cd03356d67
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -62,9 +62,7 @@ def on_pre_build(config):
     notebooks = [
         p
         for p in examples_dir.rglob("*.py")
-        if "__marimo__" not in p.parts
-        and "bugs" not in p.parts
-        and "__init__" not in p.name
+        if "__marimo__" not in p.parts and "bugs" not in p.parts and "__init__" not in p.name
     ]
     if not notebooks:
         return
@@ -119,6 +117,7 @@ def on_pre_build(config):
         msg = f"[hooks] {len(failed)} notebook(s) had cell execution errors:\n"
         msg += "\n".join(f"  - {f}" for f in failed)
         raise RuntimeError(msg)
+
 
 class _HtmlToMarkdown(HTMLParser):
     """HTML parser that converts mkdocs-material HTML to clean markdown."""
@@ -260,10 +259,7 @@ class _HtmlToMarkdown(HTMLParser):
         if self._skip_depth:
             self._skip_depth -= 1
             return
-        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
-            self._flush_line()
-            self._ensure_blank_line()
-        elif tag == "p":
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"} or tag == "p":
             self._flush_line()
             self._ensure_blank_line()
         elif tag in {"ul", "ol"}:

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,6 +1,7 @@
 """MkDocs hooks for post-build processing."""
 
 import fnmatch
+import os
 import re
 import shutil
 import subprocess
@@ -10,21 +11,38 @@ from pathlib import Path
 
 
 def on_page_markdown(markdown, page, config, files):
-    """Rewrite example links to work in both local and RTD environments.
+    """Rewrite example links for both local and RTD environments.
 
-    Converts absolute paths like /examples/ to relative paths based on page depth.
-    This works on both local builds and Read the Docs.
+    [View] links are converted to relative paths pointing to locally exported
+    static HTML notebooks.
+
+    [Open in marimo] placeholder links are resolved to the marimo online
+    playground via marimo.app. On RTD the commit SHA being built is used so
+    PR previews link to the correct revision; locally, ``main`` is used.
     """
-    # Calculate relative path based on page depth
+    # Calculate relative path based on page depth (used on all builds)
     src_parts = page.file.src_path.split("/")
-
-    # Calculate depth (pages/examples.md has depth 2, index.md has depth 0)
     depth = len(src_parts) if src_parts[-1] != "index.md" else len(src_parts) - 1
-
-    # Build relative prefix: '../' repeated for each directory level
     prefix = "../" * depth
 
-    # Replace absolute paths with relative paths
+    repo_url = config.get("repo_url", "").rstrip("/")
+    github_path = repo_url.removeprefix("https://")
+    # READTHEDOCS_GIT_IDENTIFIER is the PR number for pull-request builds,
+    # which is not a valid git ref.  READTHEDOCS_GIT_COMMIT_HASH is always
+    # the actual commit SHA checked out by RTD.
+    git_ref = os.environ.get(
+        "READTHEDOCS_GIT_COMMIT_HASH",
+        os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main"),
+    )
+    playground_base = f"https://marimo.app/{github_path}/blob/{git_ref}"
+
+    # Resolve [Open in marimo] placeholder URLs → full marimo.app playground URLs
+    markdown = re.sub(
+        r"\[Open in marimo\]\(/examples/([^)]+?)/edit/\)",
+        rf"[Open in marimo]({playground_base}/examples/\1.py)",
+        markdown,
+    )
+    # Rewrite [View] to relative paths pointing to local HTML exports
     markdown = re.sub(r"\]\(/examples/", f"]({prefix}examples/", markdown)
     return markdown
 
@@ -40,16 +58,24 @@ def on_pre_build(config):
     if not examples_dir.exists():
         return
 
-    # Find all marimo notebooks
-    notebooks = list(examples_dir.glob("*.py"))
+    # Find all marimo notebooks (recursively, excluding __marimo__ and bugs dirs)
+    notebooks = [
+        p
+        for p in examples_dir.rglob("*.py")
+        if "__marimo__" not in p.parts
+        and "bugs" not in p.parts
+        and "__init__" not in p.name
+    ]
     if not notebooks:
         return
 
     docs_examples = project_root / "docs" / "examples"
     docs_examples.mkdir(parents=True, exist_ok=True)
 
-    # Export each notebook in both static HTML and interactive WASM formats
+    failed: list[str] = []
+
     for notebook in notebooks:
+        rel_path = notebook.relative_to(project_root)
         output_dir = docs_examples / notebook.stem
 
         # Clean previous export artifacts before re-exporting
@@ -69,6 +95,7 @@ def on_pre_build(config):
                     "-q",
                     "export",
                     "html",
+                    "--no-sandbox",
                     str(notebook),
                     "-o",
                     str(static_file),
@@ -77,53 +104,21 @@ def on_pre_build(config):
                 capture_output=True,
                 text=True,
             )
-            print(
-                f"[hooks] exported html {notebook.relative_to(project_root)} -> {static_file.relative_to(project_root)}"
-            )
+            print(f"[hooks] exported html {rel_path} -> {static_file.relative_to(project_root)}")
         except subprocess.CalledProcessError as e:
-            print(f"[hooks] Error exporting html {notebook.name}: {e}", file=sys.stderr)
+            failed.append(str(rel_path))
+            print(f"[hooks] FAILED html {rel_path}: {e}", file=sys.stderr)
             if e.stderr:
                 print(e.stderr, file=sys.stderr)
+            continue
         except FileNotFoundError:
             print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
             break
 
-        # Export interactive WASM (editable in-browser)
-        edit_dir = output_dir / "edit"
-        edit_file = edit_dir / "index.html"
-        edit_dir.mkdir(parents=True, exist_ok=True)
-
-        try:
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "marimo",
-                    "-y",
-                    "-q",
-                    "export",
-                    "html-wasm",
-                    str(notebook),
-                    "-o",
-                    str(edit_file),
-                    "--mode",
-                    "edit",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            print(
-                f"[hooks] exported html-wasm {notebook.relative_to(project_root)} -> {edit_file.relative_to(project_root)}"
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"[hooks] Error exporting html-wasm {notebook.name}: {e}", file=sys.stderr)
-            if e.stderr:
-                print(e.stderr, file=sys.stderr)
-        except FileNotFoundError:
-            print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
-            break
-
+    if failed:
+        msg = f"[hooks] {len(failed)} notebook(s) had cell execution errors:\n"
+        msg += "\n".join(f"  - {f}" for f in failed)
+        raise RuntimeError(msg)
 
 class _HtmlToMarkdown(HTMLParser):
     """HTML parser that converts mkdocs-material HTML to clean markdown."""
@@ -265,7 +260,10 @@ class _HtmlToMarkdown(HTMLParser):
         if self._skip_depth:
             self._skip_depth -= 1
             return
-        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"} or tag == "p":
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._flush_line()
+            self._ensure_blank_line()
+        elif tag == "p":
             self._flush_line()
             self._ensure_blank_line()
         elif tag in {"ul", "ol"}:
@@ -407,32 +405,6 @@ def _is_excluded(relative_posix: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(relative_posix, pattern) for pattern in patterns)
 
 
-def _fix_marimo_filename(html_file: Path, notebook_name: str) -> None:
-    """Replace the default 'notebook.py' filename in marimo HTML exports.
-
-    Marimo exports always use 'notebook.py' as the default filename. This function
-    replaces it with the actual notebook name to show the correct title in browser tabs.
-
-    Note: Only the <marimo-filename> display tag is replaced. The config
-    ``"filename"`` field must stay as ``"notebook.py"`` because the marimo WASM
-    worker has that name hard-coded and writes the notebook source to
-    ``/marimo/notebook.py``. Changing the config value would cause a
-    ``FileNotFoundError`` at runtime.
-    """
-    if not html_file.exists():
-        return
-
-    html_content = html_file.read_text(encoding="utf-8")
-
-    # Replace the display tag
-    html_content = html_content.replace(
-        "<marimo-filename hidden>notebook.py</marimo-filename>",
-        f"<marimo-filename hidden>{notebook_name}.py</marimo-filename>",
-    )
-
-    html_file.write_text(html_content, encoding="utf-8")
-
-
 def _inject_rtd_css(html_file: Path) -> None:
     """Inject CSS to hide Read The Docs version menu flyout in marimo notebooks.
 
@@ -466,7 +438,7 @@ def on_post_build(config):
     project_root = Path(__file__).parent.parent
     docs_examples = project_root / "docs" / "examples"
 
-    # Copy standalone HTML example files (both static and WASM/edit)
+    # Copy standalone HTML example exports to site
     if docs_examples.exists():
         for html_dir in docs_examples.iterdir():
             if not html_dir.is_dir() or html_dir.name.startswith("."):
@@ -480,42 +452,13 @@ def on_post_build(config):
             target_dir = site_dir / "examples" / html_dir.name
             target_dir.mkdir(parents=True, exist_ok=True)
 
-            # Copy top-level files (static HTML export)
+            # Copy exported HTML files
             for file in html_dir.iterdir():
                 if file.name == "CLAUDE.md" or file.is_dir():
                     continue
                 shutil.copy2(file, target_dir / file.name)
 
-            # Inject CSS to hide RTD version menu in static HTML
-            _inject_rtd_css(target_dir / "index.html")
-
-            # Copy edit/ subdirectory (WASM export) if it exists
-            edit_src = html_dir / "edit"
-            if edit_src.exists() and edit_src.is_dir():
-                edit_target = target_dir / "edit"
-                if edit_target.exists():
-                    shutil.rmtree(edit_target)
-                shutil.copytree(
-                    edit_src,
-                    edit_target,
-                    ignore=shutil.ignore_patterns("CLAUDE.md"),
-                )
-
-                # Remove CLAUDE.md if MkDocs copied it from docs/ during build
-                claude_md = edit_target / "CLAUDE.md"
-                if claude_md.exists():
-                    claude_md.unlink()
-
-                # Fix the marimo filename in WASM export only
-                _fix_marimo_filename(edit_target / "index.html", html_dir.name)
-
-                # Inject CSS to hide RTD version menu in WASM export
-                _inject_rtd_css(edit_target / "index.html")
-
-            # Fix the marimo filename to show the actual notebook name in browser tabs
-            _fix_marimo_filename(target_dir / "index.html", html_dir.name)
-
-            # Inject CSS to hide RTD version menu in marimo notebooks
+            # Inject CSS to hide RTD version menu in exported HTML
             _inject_rtd_css(target_dir / "index.html")
 
             print(f"[hooks] copied examples/{html_dir.name}/ to site")

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -205,7 +205,6 @@ Run tests across multiple Python versions:
     ```bash
     uvx nox -s test
     ```
-
 Run example notebook tests:
 
 === "just"
@@ -228,7 +227,6 @@ Run example notebook tests:
 
 This runs all notebooks in the `examples/` directory as Python scripts in parallel using pytest-xdist (`-n auto`). Each notebook is executed non-interactively to validate it runs without errors.
 
-
 #### When to Mark Tests as Slow or Integration
 
 Mark your tests appropriately to help maintain fast feedback during development:
@@ -244,12 +242,10 @@ Mark your tests appropriately to help maintain fast feedback during development:
   - Test multiple components working together
   - Require complex setup or teardown
   - Exercise end-to-end workflows
-
 - `@pytest.mark.example` is used in `tests/test_examples.py` to:
   - Validate example notebooks execute without errors
   - Run notebooks in the `examples/` directory
   - Test interactive documentation and tutorials
-
 
 Example:
 
@@ -406,28 +402,13 @@ Create a new marimo notebook in `examples/<name>.py`:
    - **Key Takeaways**: Bullet points summarizing important lessons
    - **Next Steps**: Links to related notebooks for progression
    - Isolate utilities and markdown in separate cells
-   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
-
-   **Pyodide install cell template** (place right after `import marimo as mo`):
-
-   ```python
-   @app.cell(hide_code=True)
-   async def _():
-       import sys
-
-       if "pyodide" in sys.modules:
-           import micropip
-
-           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
-       return
-   ```
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, library imports, utilities, and markdown cells
 
    **`hide_code=True` guidance:** mark these cells as hidden:
 
    | Cell type | Why hidden |
    |-----------|-----------|
    | `import marimo as mo` | Boilerplate, not instructive |
-   | Pyodide install | Infrastructure, not tutorial content |
    | Library imports | Setup, readers focus on usage |
    | Utilities | Not the lesson |
    | Markdown cells | Purely structural |
@@ -469,10 +450,31 @@ Basic familiarity with sklearn's fit/predict API and time series concepts (trend
 
 #### Marimo Cell Conventions
 
+- Add [PEP 723](https://peps.python.org/pep-0723/) inline script metadata at the top of each notebook listing its dependencies
 - Use `hide_code=True` on all markdown cells, import cells, and utility/helper cells
-- The second cell (after `import marimo as mo`) must be the Pyodide/micropip guard for browser compatibility
-- Group all imports into a single hidden cell after the Pyodide guard
-- The overview markdown cell (with `# Title`, `## What You'll Learn`, `## Prerequisites`) follows the imports
+- Use `r"""..."""` (raw triple-quoted strings) for markdown cell content
+- Group all imports into a single hidden cell
+
+**PEP 723 header template** (place at the very top of the file, before `import marimo`):
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "my-dependency",
+# ]
+# ///
+```
+
+**What to include in `dependencies`:**
+
+- Only list packages the notebook **directly imports** (e.g., `numpy`, `plotly`)
+- Include `sklearn_optuna` when the notebook imports from the project itself
+- Do **not** include `marimo` — it is the runner, not a dependency of the script
+- Do **not** include transitive dependencies (packages already pulled in by a listed dependency)
+- Do **not** add `[tool.uv.sources]` — local development uses workspace resolution automatically; published notebooks should resolve from PyPI
+
+When in doubt, run `uv run --script examples/<name>.py` in a clean environment. If it fails with an `ImportError`, add the missing package.
 
 #### Content Guidelines
 
@@ -510,7 +512,6 @@ Add a link to your example in `docs/pages/examples.md`:
 ```
 
 The mkdocs hooks automatically export notebooks to HTML during docs build. All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
-
 ## Submitting Changes
 
 1. Push your changes to your fork:

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -36,7 +36,7 @@ Discover advanced nested optimization patterns where `OptunaSearchCV` serves as 
 
 This walkthrough demonstrates tuning sampler parameters like `n_startup_trials` using nested parameter syntax and highlights the computational trade-offs of nested searches.
 
-### Metadata Routing with sample_weight ([View](/examples/metadata_routing/) | [Open in marimo](/examples/metadata_routing/edit/)))
+### Metadata Routing with sample_weight ([View](/examples/metadata_routing/) | [Open in marimo](/examples/metadata_routing/edit/))
 
 Handle imbalanced datasets by routing `sample_weight` through `OptunaSearchCV` to both model fitting and scoring. This example shows how to configure metadata routing for estimators, scorers, and pipelines.
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -1,22 +1,22 @@
 # Examples
 
-Explore real-world applications of Sklearn-Optuna through interactive examples. Each notebook is available in two formats: **View** for static reading, and **Editable** for an interactive WASM notebook that runs entirely in your browser (no server needed).
+Explore real-world applications of Sklearn-Optuna through interactive examples. Each notebook is available in two formats: **View** for static reading, and **Open in marimo** for an interactive notebook that runs in the marimo playground.
 
 ## Getting Started
 
-### OptunaSearchCV Quickstart ([View](/examples/quickstart/) | [Editable](/examples/quickstart/edit/))
+### OptunaSearchCV Quickstart ([View](/examples/quickstart/) | [Open in marimo](/examples/quickstart/edit/))
 
 Learn how to run a fast hyperparameter search and read the best parameters and score. This example shows the fastest path from data to optimized model using familiar Scikit-Learn patterns.
 
 This walkthrough uses a compact search space and a small number of trials to keep results quick and readable.
 
-### Study Management and Reproducibility ([View](/examples/study_management/) | [Editable](/examples/study_management/edit/))
+### Study Management and Reproducibility ([View](/examples/study_management/) | [Open in marimo](/examples/study_management/edit/))
 
 Reuse an Optuna study to continue optimization runs and keep experiments reproducible with seeded samplers. This notebook demonstrates how to resume trials and compare total trial counts.
 
 This example focuses on study reuse and reproducibility without changing the core Scikit-Learn API flow.
 
-### Optuna Visualizations ([View](/examples/visualization/) | [Editable](/examples/visualization/edit/))
+### Optuna Visualizations ([View](/examples/visualization/) | [Open in marimo](/examples/visualization/edit/))
 
 Turn completed studies into visual summaries of optimization history and parameter importance. This helps explain how the search progressed and which hyperparameters mattered most.
 
@@ -24,19 +24,19 @@ The notebook uses `study_` to generate interactive plots that make diagnostics e
 
 ## Advanced Patterns
 
-### Early Stopping with Callbacks ([View](/examples/callbacks/) | [Editable](/examples/callbacks/edit/))
+### Early Stopping with Callbacks ([View](/examples/callbacks/) | [Open in marimo](/examples/callbacks/edit/))
 
 Stop unneeded work early by adding Optuna callbacks to your search. This example shows how to integrate a max-trials callback for quick experimentation.
 
 It demonstrates how to pass a dictionary of callbacks through `OptunaSearchCV` without changing your estimator code.
 
-### Nested OptunaSearchCV in Pipelines ([View](/examples/nested_pipeline/) | [Editable](/examples/nested_pipeline/edit/))
+### Nested OptunaSearchCV in Pipelines ([View](/examples/nested_pipeline/) | [Open in marimo](/examples/nested_pipeline/edit/))
 
 Discover advanced nested optimization patterns where `OptunaSearchCV` serves as a final estimator in a pipeline tuned by another `OptunaSearchCV`. This example shows how to tune preprocessing choices and sampler parameters simultaneously.
 
 This walkthrough demonstrates tuning sampler parameters like `n_startup_trials` using nested parameter syntax and highlights the computational trade-offs of nested searches.
 
-### Metadata Routing with sample_weight ([View](/examples/metadata_routing/) | [Editable](/examples/metadata_routing/edit/))
+### Metadata Routing with sample_weight ([View](/examples/metadata_routing/) | [Open in marimo](/examples/metadata_routing/edit/)))
 
 Handle imbalanced datasets by routing `sample_weight` through `OptunaSearchCV` to both model fitting and scoring. This example shows how to configure metadata routing for estimators, scorers, and pipelines.
 

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -3,6 +3,14 @@
 Learn how to use Optuna callbacks in OptunaSearchCV.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -14,16 +22,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/metadata_routing.py
+++ b/examples/metadata_routing.py
@@ -4,6 +4,15 @@ Demonstrate how to use scikit-learn's metadata routing to pass sample_weight
 through OptunaSearchCV to both model fitting and scoring.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "optuna",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -15,16 +24,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/nested_pipeline.py
+++ b/examples/nested_pipeline.py
@@ -4,6 +4,14 @@ Demonstrate an advanced pattern where OptunaSearchCV is used as a final
 estimator in a pipeline that is itself tuned by another OptunaSearchCV.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -15,16 +23,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -4,6 +4,14 @@ Run a short Optuna-powered hyperparameter search and interpret the best
 parameters and score.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -15,16 +23,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/study_management.py
+++ b/examples/study_management.py
@@ -3,6 +3,14 @@
 Learn how to reuse studies and manage optimization history.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -14,16 +22,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/visualization.py
+++ b/examples/visualization.py
@@ -3,6 +3,15 @@
 Visualize optimization history using Optuna's plotting functions.
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "plotly",
+#     "scikit-learn",
+#     "sklearn-optuna",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.19.9"
@@ -14,16 +23,6 @@ def _():
     import marimo as mo
 
     return (mo,)
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-        await micropip.install(["scikit-learn", "optuna", "plotly", "sklearn-optuna"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -242,6 +242,8 @@ def build_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
@@ -259,6 +261,8 @@ def serve_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 


### PR DESCRIPTION
Update from template v0.14.0: replace WASM notebook exports with PEP 723 inline script metadata and marimo.app playground links.

## Changes

- Remove html-wasm export from `docs/hooks.py`; export HTML-only with `--no-sandbox`
- Add marimo.app playground URL resolution for `[Open in marimo]` links
- Use `READTHEDOCS_GIT_COMMIT_HASH` for correct PR preview links on RTD
- Switch notebook discovery from `glob` to recursive `rglob`
- Fail docs build on notebook cell execution errors
- Add PEP 723 inline script metadata to all example notebooks
- Remove pyodide/micropip cell from all example notebooks
- Update contributing guide with PEP 723 dependency conventions
- Install `examples` group in `build_docs`/`serve_docs` nox sessions